### PR TITLE
feat: single token out

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -76,7 +76,15 @@ contract DeployScript is Script, Sphinx {
             _isDeployed(
                 SWAP_TERMINAL,
                 type(JBSwapTerminal).creationCode,
-                abi.encode(core.projects, core.permissions, core.directory, permit2, address(manager), IWETH9(weth), JBConstants.NATIVE_TOKEN)
+                abi.encode(
+                    core.projects,
+                    core.permissions,
+                    core.directory,
+                    permit2,
+                    address(manager),
+                    IWETH9(weth),
+                    JBConstants.NATIVE_TOKEN
+                )
             )
         ) return;
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -96,7 +96,7 @@ contract DeployScript is Script, Sphinx {
             permit2: permit2,
             _owner: address(manager),
             weth: IWETH9(weth),
-            tokenOut: JBConstants.NATIVE_TOKEN
+            _tokenOut: JBConstants.NATIVE_TOKEN
         });
     }
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -88,7 +88,7 @@ contract DeployScript is Script, Sphinx {
             permit2: permit2,
             _owner: address(manager),
             weth: IWETH9(weth),
-            tokenOut: IERC20(JBConstants.NATIVE_TOKEN)
+            tokenOut: JBConstants.NATIVE_TOKEN
         });
     }
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -2,6 +2,9 @@
 pragma solidity 0.8.23;
 
 import "@bananapus/core/script/helpers/CoreDeploymentLib.sol";
+import {JBConstants} from "@bananapus/core/src/libraries/JBConstants.sol";
+import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
 import {Sphinx} from "@sphinx-labs/contracts/SphinxPlugin.sol";
 import {Script} from "forge-std/Script.sol";
 
@@ -73,7 +76,7 @@ contract DeployScript is Script, Sphinx {
             _isDeployed(
                 SWAP_TERMINAL,
                 type(JBSwapTerminal).creationCode,
-                abi.encode(core.projects, core.permissions, core.directory, permit2, address(manager), IWETH9(weth))
+                abi.encode(core.projects, core.permissions, core.directory, permit2, address(manager), IWETH9(weth), JBConstants.NATIVE_TOKEN)
             )
         ) return;
 
@@ -84,7 +87,8 @@ contract DeployScript is Script, Sphinx {
             directory: core.directory,
             permit2: permit2,
             _owner: address(manager),
-            weth: IWETH9(weth)
+            weth: IWETH9(weth),
+            tokenOut: IERC20(JBConstants.NATIVE_TOKEN)
         });
     }
 

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -280,7 +280,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         IPermit2 permit2,
         address _owner,
         IWETH9 weth,
-        address tokenOut
+        address _tokenOut
     )
         JBPermissioned(permissions)
         Ownable(_owner)
@@ -290,11 +290,11 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         PERMIT2 = permit2;
         WETH = weth;
 
-        if (tokenOut == JBConstants.NATIVE_TOKEN) {
+        if (_tokenOut == JBConstants.NATIVE_TOKEN) {
             OUT_IS_NATIVE_TOKEN = true;
             TOKEN_OUT = address(weth);
         } else {
-            TOKEN_OUT = tokenOut;
+            TOKEN_OUT = _tokenOut;
         }
     }
 

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -109,13 +109,6 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     // ---------------- public immutable stored properties --------------- //
     //*********************************************************************//
 
-    /// @notice The token which flows out of this terminal (JBConstants.NATIVE_TOKEN for the chain native token)
-    address public immutable TOKEN_OUT;
-
-    /// @notice A flag indicating if the token out is the chain native token (eth on mainnet for instance)
-    /// @dev    If so, the token out should be unwrapped before being sent to the next terminal
-    bool public immutable OUT_IS_NATIVE_TOKEN;
-
     /// @notice Mints ERC-721s that represent project ownership and transfers.
     IJBProjects public immutable PROJECTS;
 
@@ -133,8 +126,26 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     IWETH9 public immutable WETH;
 
     //*********************************************************************//
+    // --------------- internal immutable stored properties -------------- //
+    //*********************************************************************//
+
+    /// @notice The token which flows out of this terminal (JBConstants.NATIVE_TOKEN for the chain native token)
+    address internal immutable TOKEN_OUT;
+
+    /// @notice A flag indicating if the token out is the chain native token (eth on mainnet for instance)
+    /// @dev    If so, the token out should be unwrapped before being sent to the next terminal
+    bool internal immutable OUT_IS_NATIVE_TOKEN;
+
+    //*********************************************************************//
     // ------------------------- external views -------------------------- //
     //*********************************************************************//
+
+    /// @notice Returns the token that flows out of this terminal.
+    /// @dev If the token out is the chain native token (ETH on mainnet), JBConstants NATIVE_TOKEN is returned
+    /// @return The token that flows out of this terminal.
+    function tokenOut() external view returns (address) {
+        return OUT_IS_NATIVE_TOKEN ? JBConstants.NATIVE_TOKEN : TOKEN_OUT;
+    }
 
     /// @notice Returns the default pool for a given project and token or, if a project has no default pool for the
     ///         token, the overal default pool for the token

--- a/test/Fork/TestSwapTerminal_Fork.sol
+++ b/test/Fork/TestSwapTerminal_Fork.sol
@@ -116,7 +116,8 @@ contract TestSwapTerminal_Fork is Test {
         _projectOwner = _projects.ownerOf(_projectId);
         vm.label(_projectOwner, "projectOwner");
 
-        _swapTerminal = new JBSwapTerminal(_projects, _permissions, _directory, _permit2, _owner, WETH, JBConstants.NATIVE_TOKEN);
+        _swapTerminal =
+            new JBSwapTerminal(_projects, _permissions, _directory, _permit2, _owner, WETH, JBConstants.NATIVE_TOKEN);
         vm.label(address(_swapTerminal), "swapTerminal");
 
         _metadataResolver = new MetadataResolverHelper();
@@ -224,7 +225,8 @@ contract TestSwapTerminal_Fork is Test {
 
         // Build the metadata using the minimum amount out, the pool address and the token out address
         bytes[] memory _data = new bytes[](1);
-        _data[0] = abi.encode(_minAmountOut, address(_otherTokenPool), address(_otherTokenIn) < JBConstants.NATIVE_TOKEN);
+        _data[0] =
+            abi.encode(_minAmountOut, address(_otherTokenPool), address(_otherTokenIn) < JBConstants.NATIVE_TOKEN);
 
         bytes4[] memory _ids = new bytes4[](1);
         _ids[0] = bytes4("SWAP");

--- a/test/Fork/TestSwapTerminal_Fork.sol
+++ b/test/Fork/TestSwapTerminal_Fork.sol
@@ -116,7 +116,7 @@ contract TestSwapTerminal_Fork is Test {
         _projectOwner = _projects.ownerOf(_projectId);
         vm.label(_projectOwner, "projectOwner");
 
-        _swapTerminal = new JBSwapTerminal(_projects, _permissions, _directory, _permit2, _owner, WETH, UNI);
+        _swapTerminal = new JBSwapTerminal(_projects, _permissions, _directory, _permit2, _owner, WETH, JBConstants.NATIVE_TOKEN);
         vm.label(address(_swapTerminal), "swapTerminal");
 
         _metadataResolver = new MetadataResolverHelper();
@@ -162,9 +162,9 @@ contract TestSwapTerminal_Fork is Test {
         vm.prank(_projectOwner);
         _swapTerminal.addDefaultPool(_projectId, address(UNI), POOL);
 
-        // Build the metadata using the minimum amount out, the pool address and the token out address
+        // Build the metadata using the minimum amount out, the pool address and if it's a zero to one swap
         bytes[] memory _data = new bytes[](1);
-        _data[0] = abi.encode(_minAmountOut, address(POOL), JBConstants.NATIVE_TOKEN);
+        _data[0] = abi.encode(_minAmountOut, address(POOL), address(UNI) < address(WETH));
 
         bytes4[] memory _ids = new bytes4[](1);
         _ids[0] = bytes4("SWAP");
@@ -224,7 +224,7 @@ contract TestSwapTerminal_Fork is Test {
 
         // Build the metadata using the minimum amount out, the pool address and the token out address
         bytes[] memory _data = new bytes[](1);
-        _data[0] = abi.encode(_minAmountOut, address(_otherTokenPool), JBConstants.NATIVE_TOKEN);
+        _data[0] = abi.encode(_minAmountOut, address(_otherTokenPool), address(_otherTokenIn) < JBConstants.NATIVE_TOKEN);
 
         bytes4[] memory _ids = new bytes4[](1);
         _ids[0] = bytes4("SWAP");
@@ -271,12 +271,19 @@ contract TestSwapTerminal_Fork is Test {
         vm.prank(_swapTerminal.owner());
         _swapTerminal.addDefaultPool(0, address(UNI), POOL);
 
-        assertEq(address(_swapTerminal.getPoolFor(_projectId, address(UNI))), address(POOL));
+        (IUniswapV3Pool pool, bool zeroToOne) = _swapTerminal.getPoolFor(_projectId, address(UNI));
 
+        assertEq(address(pool), address(POOL));
+        assertEq(zeroToOne, address(UNI) < address(WETH));
+
+        address newPool = makeAddr("newPool");
         vm.prank(_projects.ownerOf(_projectId));
-        _swapTerminal.addDefaultPool(_projectId, address(UNI), IUniswapV3Pool(makeAddr("newPool")));
+        _swapTerminal.addDefaultPool(_projectId, address(UNI), IUniswapV3Pool(newPool));
 
-        assertEq(address(_swapTerminal.getPoolFor(_projectId, address(UNI))), makeAddr("newPool"));
+        (pool, zeroToOne) = _swapTerminal.getPoolFor(_projectId, address(UNI));
+
+        assertEq(address(pool), newPool);
+        assertEq(zeroToOne, address(UNI) < address(WETH));
 
         vm.expectRevert(JBPermissioned.UNAUTHORIZED.selector);
         vm.prank(address(12_345));

--- a/test/Fork/TestSwapTerminal_Fork.sol
+++ b/test/Fork/TestSwapTerminal_Fork.sol
@@ -116,7 +116,7 @@ contract TestSwapTerminal_Fork is Test {
         _projectOwner = _projects.ownerOf(_projectId);
         vm.label(_projectOwner, "projectOwner");
 
-        _swapTerminal = new JBSwapTerminal(_projects, _permissions, _directory, _permit2, _owner, WETH);
+        _swapTerminal = new JBSwapTerminal(_projects, _permissions, _directory, _permit2, _owner, WETH, UNI);
         vm.label(address(_swapTerminal), "swapTerminal");
 
         _metadataResolver = new MetadataResolverHelper();

--- a/test/Invariant/Empty.t.sol
+++ b/test/Invariant/Empty.t.sol
@@ -6,5 +6,7 @@ import "forge-std/Test.sol";
 contract EmptyTest_Unit is Test {
     function setUp() public {}
 
-    function testTest() public {}
+    function testTest() public {
+        vm.skip(true);
+    }
 }

--- a/test/Units/Empty.t.sol
+++ b/test/Units/Empty.t.sol
@@ -6,5 +6,7 @@ import "forge-std/Test.sol";
 contract EmptyTest_Unit is Test {
     function setUp() public {}
 
-    function testTest() public {}
+    function testTest() public {
+        vm.skip(true);
+    }
 }


### PR DESCRIPTION
# Description

Use a single immutable token as tokenOut in the swap terminal

## Limitations & risks

Same risk-surface as previously

# Check-list
- [x] Tests are covering the new feature - unit tests to adapt in #10 
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass) - ci fails on sphinx contract size
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
SwapTerminal
- Indirectly: