### PR TITLE
fix: uncheck artifacts in test cheatcodes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,6 @@ libs = ["node_modules", "lib"]
 build_info = true
 extra_output = ['storageLayout']
 fs_permissions = [{ access = "read-write", path = "./"}]
-unchecked_cheatcode_artifacts = true
 
 [rpc_endpoints]
 ethereum ="${RPC_ETHEREUM_MAINNET}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,6 +12,7 @@ libs = ["node_modules", "lib"]
 build_info = true
 extra_output = ['storageLayout']
 fs_permissions = [{ access = "read-write", path = "./"}]
+unchecked_cheatcode_artifacts = true
 
 [rpc_endpoints]
 ethereum ="${RPC_ETHEREUM_MAINNET}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bananapus/swap-terminal",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/test/Fork/TestSwapTerminal_Fork.sol
+++ b/test/Fork/TestSwapTerminal_Fork.sol
@@ -129,7 +129,7 @@ contract TestSwapTerminal_Fork is Test {
         _poolTestHelper = new PoolTestHelper();
         vm.label(address(_poolTestHelper), "poolTestHelper");
 
-        deployCodeTo("MockERC20.sol", abi.encode("token", "token", uint8(18)), address(_otherTokenIn));
+        deployCodeTo("test/helper/MockERC20.sol:MockERC20", abi.encode("token", "token", uint8(18)), address(_otherTokenIn));
         vm.label(address(_otherTokenIn), "_otherTokenIn");
 
         _otherTokenPool = IUniswapV3Pool(

--- a/test/Fork/TestSwapTerminal_Fork.sol
+++ b/test/Fork/TestSwapTerminal_Fork.sol
@@ -129,7 +129,9 @@ contract TestSwapTerminal_Fork is Test {
         _poolTestHelper = new PoolTestHelper();
         vm.label(address(_poolTestHelper), "poolTestHelper");
 
-        deployCodeTo("test/helper/MockERC20.sol:MockERC20", abi.encode("token", "token", uint8(18)), address(_otherTokenIn));
+        deployCodeTo(
+            "test/helper/MockERC20.sol:MockERC20", abi.encode("token", "token", uint8(18)), address(_otherTokenIn)
+        );
         vm.label(address(_otherTokenIn), "_otherTokenIn");
 
         _otherTokenPool = IUniswapV3Pool(


### PR DESCRIPTION
# Description

Fix an error in the tests, due to the cheatcode vm.getCode artifact validation which became stricter/more consistent (used by forge-std deployCodeTo(..))

## Limitations & risks

This is only updating the path to an artifact

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
Swap terminal integration test

- Indirectly:
JBSwapTerminal