### PR TITLE
Clean/reduce views

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	branch = v1.3.0
 [submodule "lib/sphinx"]
 	path = lib/sphinx
 	url = https://github.com/sphinx-labs/sphinx

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -94,9 +94,9 @@ contract DeployScript is Script, Sphinx {
             permissions: core.permissions,
             directory: core.directory,
             permit2: permit2,
-            _owner: address(manager),
+            owner: address(manager),
             weth: IWETH9(weth),
-            _tokenOut: JBConstants.NATIVE_TOKEN
+            tokenOut: JBConstants.NATIVE_TOKEN
         });
     }
 

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -130,27 +130,13 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     /// @dev "wETH" is used as a generic term throughout, but any native token wrapper can be used.
     IWETH9 public immutable WETH;
 
-    //*********************************************************************//
-    // --------------- internal immutable stored properties -------------- //
-    //*********************************************************************//
 
     /// @notice The token which flows out of this terminal (JBConstants.NATIVE_TOKEN for the chain native token)
     address internal immutable TOKEN_OUT;
 
-    /// @notice A flag indicating if the token out is the chain native token (eth on mainnet for instance)
-    /// @dev    If so, the token out should be unwrapped before being sent to the next terminal
-    bool internal immutable OUT_IS_NATIVE_TOKEN;
-
     //*********************************************************************//
     // ------------------------- external views -------------------------- //
     //*********************************************************************//
-
-    /// @notice Returns the token that flows out of this terminal.
-    /// @dev If the token out is the chain native token (ETH on mainnet), JBConstants NATIVE_TOKEN is returned
-    /// @return The token that flows out of this terminal.
-    function tokenOut() external view returns (address) {
-        return OUT_IS_NATIVE_TOKEN ? JBConstants.NATIVE_TOKEN : TOKEN_OUT;
-    }
 
     /// @notice Returns the default pool for a given project and token or, if a project has no default pool for the
     ///         token, the overal default pool for the token
@@ -283,24 +269,18 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         IJBPermissions permissions,
         IJBDirectory directory,
         IPermit2 permit2,
-        address _owner,
+        address owner,
         IWETH9 weth,
-        address _tokenOut
+        address tokenOut
     )
         JBPermissioned(permissions)
-        Ownable(_owner)
+        Ownable(owner)
     {
         PROJECTS = projects;
         DIRECTORY = directory;
         PERMIT2 = permit2;
         WETH = weth;
-
-        if (_tokenOut == JBConstants.NATIVE_TOKEN) {
-            OUT_IS_NATIVE_TOKEN = true;
-            TOKEN_OUT = address(weth);
-        } else {
-            TOKEN_OUT = _tokenOut;
-        }
+        TOKEN_OUT = tokenOut;
     }
 
     //*********************************************************************//
@@ -340,7 +320,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     {
         // Get a reference to the project's primary terminal for `token`.
         IJBTerminal terminal =
-            DIRECTORY.primaryTerminalOf(projectId, OUT_IS_NATIVE_TOKEN ? JBConstants.NATIVE_TOKEN : TOKEN_OUT);
+            DIRECTORY.primaryTerminalOf(projectId, TOKEN_OUT);
 
         // Revert if the project does not have a primary terminal for `token`.
         if (address(terminal) == address(0)) revert TOKEN_NOT_ACCEPTED();
@@ -348,15 +328,15 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         uint256 receivedFromSwap = _handleTokenTransfersAndSwap(projectId, token, amount, address(terminal), metadata);
 
         // Pay the primary terminal, passing along the beneficiary and other arguments.
-        terminal.pay{value: OUT_IS_NATIVE_TOKEN ? receivedFromSwap : 0}(
-            projectId,
-            OUT_IS_NATIVE_TOKEN ? JBConstants.NATIVE_TOKEN : TOKEN_OUT,
-            receivedFromSwap,
-            beneficiary,
-            minReturnedTokens,
-            memo,
-            metadata
-        );
+        terminal.pay{value: TOKEN_OUT == JBConstants.NATIVE_TOKEN ? receivedFromSwap : 0}({
+            projectId: projectId,
+            token: TOKEN_OUT,
+            amount:receivedFromSwap,
+            beneficiary: beneficiary,
+            minReturnedTokens: minReturnedTokens,
+            memo: memo,
+            metadata: metadata
+        });
 
         return receivedFromSwap;
     }
@@ -386,7 +366,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     {
         // Get a reference to the project's primary terminal for `token`.
         IJBTerminal terminal =
-            DIRECTORY.primaryTerminalOf(projectId, OUT_IS_NATIVE_TOKEN ? JBConstants.NATIVE_TOKEN : TOKEN_OUT);
+            DIRECTORY.primaryTerminalOf(projectId, TOKEN_OUT);
 
         // Revert if the project does not have a primary terminal for `token`.
         if (address(terminal) == address(0)) revert TOKEN_NOT_ACCEPTED();
@@ -394,9 +374,9 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         uint256 receivedFromSwap = _handleTokenTransfersAndSwap(projectId, token, amount, address(terminal), metadata);
 
         // Pay the primary terminal, passing along the beneficiary and other arguments.
-        terminal.addToBalanceOf{value: OUT_IS_NATIVE_TOKEN ? receivedFromSwap : 0}(
+        terminal.addToBalanceOf{value: TOKEN_OUT == JBConstants.NATIVE_TOKEN ? receivedFromSwap : 0}(
             projectId,
-            OUT_IS_NATIVE_TOKEN ? JBConstants.NATIVE_TOKEN : TOKEN_OUT,
+            TOKEN_OUT,
             receivedFromSwap,
             shouldReturnHeldFees,
             memo,
@@ -446,7 +426,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         }
 
         // Update the project's default pool for the token.
-        _poolFor[projectId][token] = PoolConfig({pool: pool, zeroForOne: token < TOKEN_OUT});
+        _poolFor[projectId][token] = PoolConfig({pool: pool, zeroForOne: token < formattedTokenOut()});
 
         // Update the project's accounting context for the token.
         _accountingContextFor[projectId][token] = JBAccountingContext({
@@ -532,16 +512,19 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         // Accept funds for the swap.
         swapConfig.amountIn = _acceptFundsFor(swapConfig, metadata);
 
+        // Keep a reference to the formatted token out.
+        address tokenOut = formattedTokenOut();
+
         // Swap. The callback will ensure that we're within the intended slippage tolerance.
         // If the token in is the same as the token out, don't swap, just call the next terminal
-        if ((swapConfig.inIsNativeToken && OUT_IS_NATIVE_TOKEN) || (swapConfig.tokenIn == TOKEN_OUT)) {
+        if ((swapConfig.inIsNativeToken && TOKEN_OUT == JBConstants.NATIVE_TOKEN) || (swapConfig.tokenIn == tokenOut)) {
             amountToSend = swapConfig.amountIn;
         } else {
             amountToSend = _swap(swapConfig);
         }
 
         // Trigger the `beforeTransferFor` hook.
-        _beforeTransferFor(nextTerminal, TOKEN_OUT, amountToSend);
+        _beforeTransferFor(nextTerminal, tokenOut, amountToSend);
     }
 
     function _pickPoolAndQuote(
@@ -648,7 +631,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         address tokenIn = swapConfig.tokenIn;
 
         // Determine the direction of the swap based on the token addresses.
-        bool zeroForOne = tokenIn < TOKEN_OUT;
+        bool zeroForOne = tokenIn < formattedTokenOut();
 
         // Perform the swap in the specified pool, passing in parameters from the swap configuration.
         (int256 amount0, int256 amount1) = swapConfig.pool.swap({
@@ -668,7 +651,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         if (amountReceived < swapConfig.minAmountOut) revert MAX_SLIPPAGE(amountReceived, swapConfig.minAmountOut);
 
         // If the output token is a native token, unwrap it from its wrapped form.
-        if (OUT_IS_NATIVE_TOKEN) WETH.withdraw(amountReceived);
+        if (TOKEN_OUT == JBConstants.NATIVE_TOKEN) WETH.withdraw(amountReceived);
     }
 
     /// @notice Transfers tokens.
@@ -680,7 +663,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     function _transferFor(address from, address payable to, address token, uint256 amount) internal virtual {
         if (from == address(this)) {
             // If the token is native token, assume the `sendValue` standard.
-            if (OUT_IS_NATIVE_TOKEN) return Address.sendValue(to, amount);
+            if (TOKEN_OUT == JBConstants.NATIVE_TOKEN) return Address.sendValue(to, amount);
 
             // If the transfer is from this terminal, use `safeTransfer`.
             return IERC20(token).safeTransfer(to, amount);
@@ -726,5 +709,12 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
             }),
             signature: allowance.signature
         });
+    }
+
+    /// @notice Returns the token that flows out of this terminal, wrapped as an ERC-20 if needed.
+    /// @dev If the token out is the chain native token (ETH on mainnet), wrapped ETH is returned
+    /// @return The token that flows out of this terminal.
+    function formattedTokenOut() internal view returns (address) {
+        return TOKEN_OUT == JBConstants.NATIVE_TOKEN ? address(WETH) : TOKEN_OUT;
     }
 }

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -501,7 +501,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         SwapConfig memory swapConfig;
         swapConfig.projectId = projectId;
 
-        if (OUT_IS_NATIVE_TOKEN) {
+        if (token == JBConstants.NATIVE_TOKEN) {
             // If the token being paid in is the native token, use `msg.value`.
             swapConfig.tokenIn = address(WETH);
             swapConfig.inIsNativeToken = true;

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -130,9 +130,8 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     /// @dev "wETH" is used as a generic term throughout, but any native token wrapper can be used.
     IWETH9 public immutable WETH;
 
-
     /// @notice The token which flows out of this terminal (JBConstants.NATIVE_TOKEN for the chain native token)
-    address internal immutable TOKEN_OUT;
+    address public immutable TOKEN_OUT;
 
     //*********************************************************************//
     // ------------------------- external views -------------------------- //

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -318,8 +318,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         returns (uint256)
     {
         // Get a reference to the project's primary terminal for `token`.
-        IJBTerminal terminal =
-            DIRECTORY.primaryTerminalOf(projectId, TOKEN_OUT);
+        IJBTerminal terminal = DIRECTORY.primaryTerminalOf(projectId, TOKEN_OUT);
 
         // Revert if the project does not have a primary terminal for `token`.
         if (address(terminal) == address(0)) revert TOKEN_NOT_ACCEPTED();
@@ -330,7 +329,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         terminal.pay{value: TOKEN_OUT == JBConstants.NATIVE_TOKEN ? receivedFromSwap : 0}({
             projectId: projectId,
             token: TOKEN_OUT,
-            amount:receivedFromSwap,
+            amount: receivedFromSwap,
             beneficiary: beneficiary,
             minReturnedTokens: minReturnedTokens,
             memo: memo,
@@ -364,8 +363,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         override
     {
         // Get a reference to the project's primary terminal for `token`.
-        IJBTerminal terminal =
-            DIRECTORY.primaryTerminalOf(projectId, TOKEN_OUT);
+        IJBTerminal terminal = DIRECTORY.primaryTerminalOf(projectId, TOKEN_OUT);
 
         // Revert if the project does not have a primary terminal for `token`.
         if (address(terminal) == address(0)) revert TOKEN_NOT_ACCEPTED();
@@ -374,12 +372,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
 
         // Pay the primary terminal, passing along the beneficiary and other arguments.
         terminal.addToBalanceOf{value: TOKEN_OUT == JBConstants.NATIVE_TOKEN ? receivedFromSwap : 0}(
-            projectId,
-            TOKEN_OUT,
-            receivedFromSwap,
-            shouldReturnHeldFees,
-            memo,
-            metadata
+            projectId, TOKEN_OUT, receivedFromSwap, shouldReturnHeldFees, memo, metadata
         );
     }
 


### PR DESCRIPTION
# Description

Avoid need for underscore name conflict in constructor by changing TOKEN_OUT to reference unwrapped version of native token.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: