### PR TITLE
fix: include amount in quote calculation

### DIFF
--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -335,7 +335,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         uint256 receivedFromSwap = _handleTokenTransfersAndSwap(projectId, token, amount, address(terminal), metadata);
 
         // Pay the primary terminal, passing along the beneficiary and other arguments.
-        terminal.pay{value: OUT_IS_NATIVE_TOKEN ? receivedFromSwap : 0}({
+        return terminal.pay{value: OUT_IS_NATIVE_TOKEN ? receivedFromSwap : 0}({
             projectId: projectId,
             token: TOKEN_OUT,
             amount: receivedFromSwap,
@@ -344,8 +344,6 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
             memo: memo,
             metadata: metadata
         });
-
-        return receivedFromSwap;
     }
 
     /// @notice Accepts funds for a given project, swaps them if necessary, and adds them to the project's balance in

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -418,7 +418,8 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
 
     /// @notice Set a project's default pool and accounting context for the specified token. Only the project's owner,
     /// an address with `MODIFY_DEFAULT_POOL` permission from the owner or the terminal owner can call this function.
-    /// @dev This does not set the twap parameters, they *must* be set using `addTwapParamsFor` (if not, the twap duration will be 0
+    /// @dev This does not set the twap parameters, they *must* be set using `addTwapParamsFor` (if not, the twap
+    /// duration will be 0
     /// which will cause the swap to revert).
     /// @param projectId The ID of the project to set the default pool for. The project 0 acts as a catch-all, where
     /// non-set pools are defaulted to.

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -420,6 +420,8 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
 
     /// @notice Set a project's default pool and accounting context for the specified token. Only the project's owner,
     /// an address with `MODIFY_DEFAULT_POOL` permission from the owner or the terminal owner can call this function.
+    /// @dev This does not set the twap parameters, they *must* be set using `addTwapParamsFor` (if not, the twap duration will be 0
+    /// which will cause the swap to revert).
     /// @param projectId The ID of the project to set the default pool for. The project 0 acts as a catch-all, where
     /// non-set pools are defaulted to.
     /// @param token The address of the token to set the default pool for.

--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -513,7 +513,7 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         }
 
         (swapConfig.minAmountOut, swapConfig.pool, swapConfig.zeroForOne) =
-            _pickPoolAndQuote(metadata, projectId, swapConfig.tokenIn);
+            _pickPoolAndQuote(metadata, projectId, swapConfig.tokenIn, amount);
 
         // Accept funds for the swap.
         swapConfig.amountIn = _acceptFundsFor(swapConfig, metadata);
@@ -536,58 +536,52 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
     function _pickPoolAndQuote(
         bytes calldata metadata,
         uint256 projectId,
-        address token
+        address token,
+        uint256 amountIn
     )
         internal
         view
         returns (uint256 minAmountOut, IUniswapV3Pool pool, bool zeroForOne)
     {
-        {
-            // Check for a quote passed in by the user/client.
-            (bool exists, bytes memory quote) =
-                JBMetadataResolver.getDataFor(JBMetadataResolver.getId("quoteForSwap"), metadata);
+        // Check for a quote passed in by the user/client.
+        (bool exists, bytes memory quote) =
+            JBMetadataResolver.getDataFor(JBMetadataResolver.getId("quoteForSwap"), metadata);
 
-            if (exists) {
-                // If there is a quote, use it for the swap config.
-                (minAmountOut, pool, zeroForOne) = abi.decode(quote, (uint256, IUniswapV3Pool, bool));
-            } else {
-                // If there is no quote, check for this project's default pool for the token and get a quote based on
-                // its TWAP.
-                PoolConfig storage poolConfig = _poolFor[projectId][token];
+        if (exists) {
+            // If there is a quote, use it for the swap config.
+            (minAmountOut, pool, zeroForOne) = abi.decode(quote, (uint256, IUniswapV3Pool, bool));
+        } else {
+            // If there is no quote, check for this project's default pool for the token and get a quote based on
+            // its TWAP.
+            PoolConfig storage poolConfig = _poolFor[projectId][token];
+            (pool, zeroForOne) = (poolConfig.pool, poolConfig.zeroForOne);
+
+            // If this project doesn't have a default pool specified for this token, try using a generic one.
+            if (address(pool) == address(0)) {
+                poolConfig = _poolFor[DEFAULT_PROJECT_ID][token];
                 (pool, zeroForOne) = (poolConfig.pool, poolConfig.zeroForOne);
 
-                // If this project doesn't have a default pool specified for this token, try using a generic one.
-                if (address(pool) == address(0)) {
-                    poolConfig = _poolFor[DEFAULT_PROJECT_ID][token];
-                    (pool, zeroForOne) = (poolConfig.pool, poolConfig.zeroForOne);
-
-                    // If there's no default pool neither, revert.
-                    if (address(pool) == address(0)) revert NO_DEFAULT_POOL_DEFINED();
-                }
-
-                // Get a quote based on the pool's TWAP, including a default slippage maximum.
-                minAmountOut = _getTwapFrom(pool, projectId, zeroForOne);
+                // If there's no default pool neither, revert.
+                if (address(pool) == address(0)) revert NO_DEFAULT_POOL_DEFINED();
             }
+
+            // Get a quote based on the pool's TWAP, including a default slippage maximum.
+            (uint32 secondsAgo, uint160 slippageTolerance) = twapParamsOf(projectId, pool);
+
+            // Keep a reference to the TWAP tick.
+            (int24 arithmeticMeanTick,) = OracleLibrary.consult(address(pool), secondsAgo);
+
+            // Get a quote based on this TWAP tick.
+            minAmountOut = OracleLibrary.getQuoteAtTick({
+                tick: arithmeticMeanTick,
+                baseAmount: uint128(amountIn),
+                baseToken: token,
+                quoteToken: TOKEN_OUT == JBConstants.NATIVE_TOKEN ? address(WETH) : address(TOKEN_OUT)
+            });
+
+            // Return the lowest acceptable return based on the TWAP and its parameters.
+            minAmountOut -= (minAmountOut * slippageTolerance) / SLIPPAGE_DENOMINATOR;
         }
-    }
-
-    /// @notice Get a quote based on the TWAP.
-    /// @dev The TWAP is calculated over `secondsAgo` seconds, and the quote cannot unfavourably deviate from the TWAP
-    /// by more than `slippageTolerance` (as a fraction out of `SLIPPAGE_DENOMINATOR`).
-    function _getTwapFrom(IUniswapV3Pool pool, uint256 projectId, bool zeroForOne) internal view returns (uint160) {
-        // Unpack the project's TWAP params and get a reference to the period and slippage.
-        (uint32 secondsAgo, uint160 slippageTolerance) = twapParamsOf(projectId, pool);
-
-        // Keep a reference to the TWAP tick.
-        (int24 arithmeticMeanTick,) = OracleLibrary.consult(address(pool), secondsAgo);
-
-        // Get a quote based on that TWAP tick.
-        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(arithmeticMeanTick);
-
-        // Return the lowest acceptable price for the swap based on the TWAP and slippage tolerance.
-        return zeroForOne
-            ? sqrtPriceX96 - (sqrtPriceX96 * slippageTolerance) / SLIPPAGE_DENOMINATOR
-            : sqrtPriceX96 + (sqrtPriceX96 * slippageTolerance) / SLIPPAGE_DENOMINATOR;
     }
 
     /// @notice Accepts a token being paid in.

--- a/test/Fork/TestSwapTerminal_Fork.sol
+++ b/test/Fork/TestSwapTerminal_Fork.sol
@@ -227,14 +227,9 @@ contract TestSwapTerminal_Fork is Test {
         _swapTerminal.addDefaultPool(_projectId, address(UNI), POOL);
 
         vm.prank(_projectOwner);
-        _swapTerminal.addTwapParamsFor({
-            projectId: _projectId,
-            pool: POOL,
-            secondsAgo: 60,
-            slippageTolerance: 500
-        });
-        
-        bytes memory _metadata = '';
+        _swapTerminal.addTwapParamsFor({projectId: _projectId, pool: POOL, secondsAgo: 60, slippageTolerance: 500});
+
+        bytes memory _metadata = "";
 
         // Approve the transfer
         vm.startPrank(_sender);
@@ -271,7 +266,6 @@ contract TestSwapTerminal_Fork is Test {
         );
     }
 
-
     /// @notice Test paying a swap terminal in UNI to contribute to JuiceboxDAO project (in the eth terminal), using
     /// a twap
     /// @dev    Quote at the forked block 5022528 : 1 UNI = 1.33649 ETH with max slippage suggested (uni sdk): 0.5%
@@ -292,15 +286,17 @@ contract TestSwapTerminal_Fork is Test {
             secondsAgo: 60,
             slippageTolerance: 500 // max slippage allowed is 5%
         });
-        
-        bytes memory _metadata = '';
+
+        bytes memory _metadata = "";
 
         // Approve the transfer
         vm.startPrank(_sender);
         UNI.approve(address(_swapTerminal), _amountIn);
 
         // Funny value
-        vm.expectRevert(abi.encodeWithSelector(JBSwapTerminal.MAX_SLIPPAGE.selector, _amountOut, 126148869380486231752));
+        vm.expectRevert(
+            abi.encodeWithSelector(JBSwapTerminal.MAX_SLIPPAGE.selector, _amountOut, 126_148_869_380_486_231_752)
+        );
 
         // Make a payment.
         _swapTerminal.pay({


### PR DESCRIPTION
# Description

Fix an error in the quote calculation based on a twap, finding of audits

## Limitations & risks

Trade-off: we blindly use the average tick as if it was uni v2, meaning get the twap (expressed in tick) then get what amount out you'd get _at that price_, but it isn't uni v2, we have 0 idea of how the liquidity profile is around that tick -> that's highly vulnerable to any kind of just in time liquidity manipulation ("reverse"/just in time liq burn for instance, stabilise the price with a huge liquidity for x blocks, then when a noticeable bb or swap comes, remove almost everything and boom big slippage)

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
Swap terminal
- Indirectly:
/