### PR TITLE
feat: normalize tokenin in getpoolfor

### DIFF
--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -139,6 +139,9 @@ contract JBSwapTerminal is JBPermissioned, Ownable, IJBTerminal, IJBPermitTermin
         view
         returns (IUniswapV3Pool pool, bool zeroForOne)
     {
+        // Convert the token in as weth if it's the native token
+        tokenIn = tokenIn == JBConstants.NATIVE_TOKEN ? address(WETH) : tokenIn;
+
         // Get the pool for the project ID and token.
         pool = _poolFor[projectId][tokenIn];
 


### PR DESCRIPTION
# Description

tokenIn in getPoolFor might be the jbconstant for eth and should therefore be normalized

## Limitations & risks

NA

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
JBSwapTerminal.getPoolFor

- Indirectly:
Third parties relying on onchain access to getPoolFor